### PR TITLE
Update get_veolia_idf_consommation.py

### DIFF
--- a/get_veolia_idf_consommation.py
+++ b/get_veolia_idf_consommation.py
@@ -87,6 +87,7 @@ class VeoliaIdf:
         assert len(csv_files)==1
         csv_file = open(csv_files[0])
         reader = csv.reader(csv_file, delimiter=';')
+        next(reader)
         r = [e for e in reader]
         logging.debug(r)
         if len(r) != 91:


### PR DESCRIPTION
Pour sauter la première ligne du fichier csv et éviter l'erreur : 
```
PHP Fatal error:  Uncaught Exception: [MySQL] Error code : 22007 (1292). Incorrect datetime value: '﻿Date de relevé' for column `jeedom`.`history`.`datetime` at row 1  : REPLACE INTO history
						SET cmd_id=:cmd_id,
						`datetime`=:datetime,
						value=:value in /var/www/html/core/class/DB.class.php:101
Stack trace:
#0 /var/www/html/core/class/history.class.php(928): DB::Prepare('REPLACE INTO hi...', Array, 0)
#1 /var/www/html/core/class/cmd.class.php(1802): history->save(Object(scriptCmd))
#2 /root/conso_veolia/jeedom_php_history_veolia.php(17): cmd->addHistoryValue('Index relev\xC3\xA9 (...', '\xEF\xBB\xBFDate de rele...')
#3 {main}
  thrown in /var/www/html/core/class/DB.class.php on line 101
```